### PR TITLE
Issue 4 - Add flag to prevent parsing of a container's body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,13 @@ Since this package is starting to be used by the wider world, I'll start a chang
 
 I try to keep to semantic versioning.
 
-## 1.2.0
+## 1.1.3
+
+### Added
+
+- `noparse` keyword after `:::` prevents parsing the content of the container. 
+
+## 1.1.2
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,14 @@ Since this package is starting to be used by the wider world, I'll start a chang
 
 I try to keep to semantic versioning.
 
-## 1.1.3
+## 1.2.0
+
+**Minor Compatibility Warning** This version reintroduces named regex captures. They were removed earlier because of lack of browser support, [but the situation has improved](https://caniuse.com/#feat=mdn-javascript_builtins_regexp_named_capture_groups). 
 
 ### Added
 
-- `noparse` keyword after `:::` prevents parsing the content of the container. 
+- `noparse` keyword after `:::` prevents treats the body of the container as raw text. 
+
 
 ## 1.1.2
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This [remark] plugin provides parsing for containers in your markdown.
 
 ## Default Syntax
 
-Containers begin with `::: [noparse] {HTML Element Name} [optional list of classes]` on a new line, and end with `:::` on a new line. 
+Containers begin with `::: [noparse] {HTML Element Name} [optional list of classes]` on a new line, and end with `:::` on a new line. Container markers may be indented by up to 2 spaces.
 
 For example:
 
@@ -25,14 +25,43 @@ renders as:
 </aside>
 ```
 
-Containers can be indented by up to 2 spaces.
-
-Containers can also be nested.
+### Containers may be nested
 
 For example: 
 
 ```markdown
 ::: div outer
+# Header One
+
+Outer contents.
+
+  ::: div inner
+  Inner contents.
+  :::
+
+More outer contents.
+::: 
+```
+
+renders as:
+
+```html
+<div class="outer">           
+  <h1>Header One</h1>         
+  <p>Outer contents.</p>      
+  <div class="inner">         
+    <p>Inner contents.</p>    
+  </div>                      
+  <p>More outer contents.</p> 
+</div>                        
+```
+
+### `noparse` stops processing of the container contents and instead treats it as raw text.
+
+For example: 
+
+```markdown
+::: noparse div outer
 # Header One
 
 Outer contents.
@@ -49,12 +78,12 @@ renders as:
 
 ```html
 <div class="outer">           
-  <h1>Header One</h1>         
-  <p>Outer contents.</p>      
-  <div class="inner">         
-    <p>Inner contents.</p>    
-  </div>                      
-  <p>More outer contents.</p> 
+# Header One
+Outer contents.
+::: div inner
+Inner contents. 
+:::
+More outer contents.
 </div>                        
 ```
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This [remark] plugin provides parsing for containers in your markdown.
 
 ## Default Syntax
 
-Containers begin with `::: {HTML Element Name} [optional list of classes]` on a new line, and end with `:::` on a new line. 
+Containers begin with `::: [noparse] {HTML Element Name} [optional list of classes]` on a new line, and end with `:::` on a new line. 
 
 For example:
 

--- a/harness.js
+++ b/harness.js
@@ -53,8 +53,8 @@ var processor = unified()
    })
 
    .use(remark2rehype)
-   .use(format)
-   .use(html)
+   // .use(format)
+   .use(html, {})
 
 
 
@@ -99,14 +99,21 @@ const fs = require('fs')
 
 
 let text = `
-::: noparse quote as stated by john doe
+::: noparse div outer
 # Header One
-Contents.
-:::
+
+Outer contents.
+
+ ::: div inner
+ Inner contents. 
+ :::
+
+More outer contents.
+::: 
 `
 
 console.log(text)
 processor.process(text, function (err, file) {
    console.error(report(err || file))
-   console.log(String(file))
+   console.log(file.toString())
 })

--- a/harness.js
+++ b/harness.js
@@ -19,7 +19,7 @@ var processor = unified()
       custom: [{
          type: 'sidebar',
          element: 'aside',
-         transform: function(node, config, tokenize) {
+         transform: function (node, config, tokenize) {
             node.data.hProperties = {
                className: config || 'left'
             }
@@ -27,7 +27,7 @@ var processor = unified()
       }, {
          type: 'callout',
          element: 'article',
-         transform: function(node, config, tokenize) {
+         transform: function (node, config, tokenize) {
             node.data.hProperties = {
                className: config || 'left'
             }
@@ -35,7 +35,7 @@ var processor = unified()
       }, {
          type: 'quote',
          element: 'aside',
-         transform: function(node, config, tokenize) {
+         transform: function (node, config, tokenize) {
             var words = tokenizeWords.parse(config)
 
             node.data.hProperties = {
@@ -82,29 +82,31 @@ const fs = require('fs')
 // :::
 // `
 
-const text = `
-::: div outer
-# Header One
-Outer contents.
-
-  ::: div inner
-  Inner contents. 
-  :::
-
-More outer contents.
-:::
-`
-
-
-// let text = `
-// ::: div
+// const text = `
+// ::: div outer
 // # Header One
-// Contents.
+// Outer contents.
+
+// ::: quote quote attribution
+// - not 
+// - to be 
+// - parsed
+// :::
+
+// More outer contents.
 // :::
 // `
 
+
+let text = `
+::: noparse quote as stated by john doe
+# Header One
+Contents.
+:::
+`
+
 console.log(text)
-processor.process(text, function(err, file) {
+processor.process(text, function (err, file) {
    console.error(report(err || file))
    console.log(String(file))
 })

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remark-containers",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Markdown parsing for custom containers",
   "main": "src/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remark-containers",
-  "version": "1.1.3",
+  "version": "1.2.0",
   "description": "Markdown parsing for custom containers",
   "main": "src/index.js",
   "scripts": {

--- a/test/test.js
+++ b/test/test.js
@@ -57,7 +57,6 @@ function runTests(tests, processor) {
    })
 }
 
-
 describe('basic usage', function () {
 
    let processor = unified()
@@ -118,6 +117,17 @@ Contents.
 :::   
 `,
       expected: `<div><h1>Header One</h1><p>Contents.</p></div>`
+   },
+   {
+      testing: 'noparse disables markdown parsing of container contents for default syntax',
+      md: `
+::: noparse hero
+# Header One
+- list
+- *list*
+:::   
+`,
+      expected: `<hero># Header One\n- list\n- *list*</hero>`
    }
    ]
 
@@ -159,3 +169,44 @@ More outer contents.
 
    runTests(tests, processor)
 })
+
+
+// todo - add tests for custom containers too
+
+// describe('configuration', function () {
+
+//    let processor = unified()
+//       .use(markdown, { commonmark: true })
+//       .use(containers, {})
+//       .use(remark2rehype)
+//       .use(html)
+
+
+//    let tests = [{
+//       testing: "default false",
+//       md: `
+// ::: div
+
+// # Header One
+
+// Contents.
+
+// :::
+// `,
+//       expected: `<div><h1>Header One</h1><p>Contents.</p></div>`
+//    }, {
+//       testing: "can skip specific containers",
+//       md: `
+// ::: div
+
+// # Header One
+
+// Contents.
+
+// :::
+// `,
+//       expected: `<div><h1>Header One</h1><p>Contents.</p></div>`
+//    }]
+
+//    runTests(tests, processor)
+// })


### PR DESCRIPTION
Adds an optional flag which will prevent parsing of the body of a container. When present the container's contents will be treated as raw text.